### PR TITLE
fix(settings): ensure default data uses literal types

### DIFF
--- a/example-usage.ts
+++ b/example-usage.ts
@@ -237,7 +237,7 @@ const settingsRepo = new SingletonRepository(
   'user_settings',
   UserSettings,
   SETTINGS_VERSION,
-  () => ({
+  (): UserSettingsData => ({
     version: SETTINGS_VERSION,
     typeName: 'user_settings',
     theme: 'auto',


### PR DESCRIPTION
## Summary
- enforce `UserSettings` default data to return `UserSettingsData` so literal fields like `version` stay typed

## Testing
- `npm run lint`
- `npx tsc --noEmit example-usage.ts`
- `npx tsc --noEmit` *(fails: Cannot find module 'zod')*
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_68a6102600f083209cc030294f5be147