### PR TITLE
fix: properly export DatabaseStorable type

### DIFF
--- a/repository.ts
+++ b/repository.ts
@@ -253,9 +253,12 @@ class SingletonRepository<TClass extends BaseClass<TData>, TData extends Databas
   }
 }
 
-export { 
-  Repository, 
-  SingletonRepository, 
-  BaseClass, 
+export {
+  Repository,
+  SingletonRepository,
+  BaseClass
+}
+
+export type {
   DatabaseStorable
 }


### PR DESCRIPTION
## Summary
- correctly re-export `DatabaseStorable` using `export type`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_68a61bf049708320a6dd0c5c37c7fe93