### PR TITLE
Restrict Supabase clients to auth-only interface

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,4 +1,3 @@
-Hide supabase browserClient and serverClient, only expose auth parts, to prevent tempting to use it, since we'll be using the repository pattern instead.
 Create example repository for user profile (seems like it should be generic enough that you pretty much always want that anyway)
 Add sentry
 Add logtail

--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@/lib/supabase/server";
+import { createAuthClient } from "@/lib/supabase/server";
 import { type EmailOtpType } from "@supabase/supabase-js";
 import { redirect } from "next/navigation";
 import { type NextRequest } from "next/server";
@@ -10,9 +10,9 @@ export async function GET(request: NextRequest) {
   const next = searchParams.get("next") ?? "/";
 
   if (token_hash && type) {
-    const supabase = await createClient();
+    const auth = await createAuthClient();
 
-    const { error } = await supabase.auth.verifyOtp({
+    const { error } = await auth.verifyOtp({
       type,
       token_hash,
     });

--- a/app/protected/page.tsx
+++ b/app/protected/page.tsx
@@ -1,19 +1,16 @@
 import { redirect } from "next/navigation";
 
-import { createClient } from "@/lib/supabase/server";
+import { createAuthClient } from "@/lib/supabase/server";
 import { InfoIcon } from "lucide-react";
 import { FetchDataSteps } from "@/components/tutorial/fetch-data-steps";
-import { Database } from "@/supabase/database.types";
 
 export default async function ProtectedPage() {
-  const supabase = await createClient<Database>();
+  const auth = await createAuthClient();
 
-  const { data, error } = await supabase.auth.getClaims();
+  const { data, error } = await auth.getClaims();
   if (error || !data?.claims) {
     redirect("/auth/login");
   }
-
-  const {data: notes, error: notesError} = await supabase.from("notes").select("*");
 
   return (
     <div className="flex-1 w-full flex flex-col gap-12">
@@ -28,10 +25,6 @@ export default async function ProtectedPage() {
         <h2 className="font-bold text-2xl mb-4">Your user details</h2>
         <pre className="text-xs font-mono p-3 rounded border max-h-32 overflow-auto">
           {JSON.stringify(data.claims, null, 2)}
-        </pre>
-        <h2 className="font-bold text-2xl mb-4">Your notes</h2>
-        <pre className="text-xs font-mono p-3 rounded border max-h-32 overflow-auto">
-          {notesError ? JSON.stringify(notesError, null, 2) : JSON.stringify(notes, null, 2)}
         </pre>
       </div>
       <div>

--- a/components/auth-button.tsx
+++ b/components/auth-button.tsx
@@ -1,13 +1,13 @@
 import Link from "next/link";
 import { Button } from "./ui/button";
-import { createClient } from "@/lib/supabase/server";
+import { createAuthClient } from "@/lib/supabase/server";
 import { LogoutButton } from "./logout-button";
 
 export async function AuthButton() {
-  const supabase = await createClient();
+  const auth = await createAuthClient();
 
   // You can also use getUser() which will be slower.
-  const { data } = await supabase.auth.getClaims();
+  const { data } = await auth.getClaims();
 
   const user = data?.claims;
 

--- a/components/forgot-password-form.tsx
+++ b/components/forgot-password-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { createClient } from "@/lib/supabase/client";
+import { createAuthClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -26,13 +26,13 @@ export function ForgotPasswordForm({
 
   const handleForgotPassword = async (e: React.FormEvent) => {
     e.preventDefault();
-    const supabase = createClient();
+    const auth = createAuthClient();
     setIsLoading(true);
     setError(null);
 
     try {
       // The url which will be included in the email. This URL needs to be configured in your redirect URLs in the Supabase dashboard at https://supabase.com/dashboard/project/_/auth/url-configuration
-      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      const { error } = await auth.resetPasswordForEmail(email, {
         redirectTo: `${window.location.origin}/auth/update-password`,
       });
       if (error) throw error;

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { createClient } from "@/lib/supabase/client";
+import { createAuthClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -28,12 +28,12 @@ export function LoginForm({
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
-    const supabase = createClient();
+    const auth = createAuthClient();
     setIsLoading(true);
     setError(null);
 
     try {
-      const { error } = await supabase.auth.signInWithPassword({
+      const { error } = await auth.signInWithPassword({
         email,
         password,
       });

--- a/components/logout-button.tsx
+++ b/components/logout-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createClient } from "@/lib/supabase/client";
+import { createAuthClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
 import { useRouter } from "next/navigation";
 
@@ -8,8 +8,8 @@ export function LogoutButton() {
   const router = useRouter();
 
   const logout = async () => {
-    const supabase = createClient();
-    await supabase.auth.signOut();
+    const auth = createAuthClient();
+    await auth.signOut();
     router.push("/auth/login");
   };
 

--- a/components/sign-up-form.tsx
+++ b/components/sign-up-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { createClient } from "@/lib/supabase/client";
+import { createAuthClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -29,7 +29,7 @@ export function SignUpForm({
 
   const handleSignUp = async (e: React.FormEvent) => {
     e.preventDefault();
-    const supabase = createClient();
+    const auth = createAuthClient();
     setIsLoading(true);
     setError(null);
 
@@ -40,7 +40,7 @@ export function SignUpForm({
     }
 
     try {
-      const { error } = await supabase.auth.signUp({
+      const { error } = await auth.signUp({
         email,
         password,
         options: {

--- a/components/update-password-form.tsx
+++ b/components/update-password-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { createClient } from "@/lib/supabase/client";
+import { createAuthClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -26,12 +26,12 @@ export function UpdatePasswordForm({
 
   const handleForgotPassword = async (e: React.FormEvent) => {
     e.preventDefault();
-    const supabase = createClient();
+    const auth = createAuthClient();
     setIsLoading(true);
     setError(null);
 
     try {
-      const { error } = await supabase.auth.updateUser({ password });
+      const { error } = await auth.updateUser({ password });
       if (error) throw error;
       // Update this route to redirect to an authenticated route. The user already has an active session.
       router.push("/protected");

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,8 +1,9 @@
 import { createBrowserClient } from "@supabase/ssr";
 
-export function createClient<T>() {
-  return createBrowserClient<T>(
+// Return only the auth interface to discourage direct data access
+export function createAuthClient() {
+  return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-  );
+  ).auth;
 }

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -6,10 +6,10 @@ import { cookies } from "next/headers";
  * global variable. Always create a new client within each function when using
  * it.
  */
-export async function createClient<T>() {
+export async function createAuthClient() {
   const cookieStore = await cookies();
 
-  return createServerClient<T>(
+  return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
@@ -30,5 +30,5 @@ export async function createClient<T>() {
         },
       },
     },
-  );
+  ).auth;
 }


### PR DESCRIPTION
## Summary
- expose only the `auth` interface from Supabase browser and server clients
- refactor auth-related components and routes to use the new auth-only client
- remove sample data fetching from the protected page
- update TODO list
- rename helpers to `createAuthClient` for clarity

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_68a63854a4d88320a3242a4d06ca93e1