### PR TITLE
Add monitoring and testing scaffolding

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,7 +1,2 @@
-Add sentry
-Add logtail
-Add Jest
-Add Cypress
-Add Chromatic
 Add /api/log endpoint for browser side logging, and even then, only upon request by user to provide support (flag should be stored in user settings, off by default and checked before actually logging.
 Strip away resources that aren't relevant, so we have the cleanest template we can think of.

--- a/Template.md
+++ b/Template.md
@@ -22,6 +22,15 @@ Add project id to package.json for type generation if desired, but with the repo
 
 This template comes with the default shadcn/ui style initialized. If you instead want other ui.shadcn styles, delete `components.json` and [re-install shadcn/ui](https://ui.shadcn.com/docs/installation/next)
 
+### Environment variables
+
+| Variable | Functionality |
+| --- | --- |
+| `SENTRY_DSN` | Enable Sentry error monitoring |
+| `LOGTAIL_SOURCE_TOKEN` | Configure Logtail logging |
+| `CYPRESS_RECORD_KEY` | Record Cypress tests to Cypress Cloud |
+| `CHROMATIC_PROJECT_TOKEN` | Publish Storybook builds to Chromatic |
+
 ## More Supabase examples
 
 - [Next.js Subscription Payments Starter](https://github.com/vercel/nextjs-subscription-payments)

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+  e2e: {
+    baseUrl: "http://localhost:3000",
+  },
+});

--- a/cypress/e2e/sample.cy.ts
+++ b/cypress/e2e/sample.cy.ts
@@ -1,0 +1,5 @@
+describe("sample", () => {
+  it("works", () => {
+    expect(true).to.equal(true);
+  });
+});

--- a/example.test.ts
+++ b/example.test.ts
@@ -1,0 +1,5 @@
+describe("example", () => {
+  it("works", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/$1",
+  },
+};
+
+export default config;

--- a/lib/logtail.ts
+++ b/lib/logtail.ts
@@ -1,0 +1,5 @@
+import { Logtail } from "@logtail/node";
+
+export const logtail = new Logtail(process.env.LOGTAIL_SOURCE_TOKEN || "");
+
+export default logtail;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,9 @@
 import type { NextConfig } from "next";
+import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig: NextConfig = {
   /* config options here */
   productionBrowserSourceMaps: true,
 };
 
-export default nextConfig;
+export default withSentryConfig(nextConfig, { silent: true });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@supabase/ssr": "latest",
     "@supabase/supabase-js": "latest",
     "@sentry/nextjs": "^8.0.0",
-    "@logtail/node": "^1.0.0",
+    "@logtail/node": "^0.5.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.511.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "update-types": "supabase gen types typescript --project-id cvgiqfbpsrsukgrqzfuo --schema public > supabase/database.types.ts"
+    "update-types": "supabase gen types typescript --project-id cvgiqfbpsrsukgrqzfuo --schema public > supabase/database.types.ts",
+    "test": "jest",
+    "cy:run": "cypress run",
+    "chromatic": "chromatic --project-token $CHROMATIC_PROJECT_TOKEN"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.1",
@@ -14,6 +17,8 @@
     "@radix-ui/react-slot": "^1.2.2",
     "@supabase/ssr": "latest",
     "@supabase/supabase-js": "latest",
+    "@sentry/nextjs": "^8.0.0",
+    "@logtail/node": "^1.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.511.0",
@@ -35,6 +40,11 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "@types/jest": "^29.0.0",
+    "cypress": "^13.0.0",
+    "chromatic": "^10.0.0"
   }
 }

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,0 +1,6 @@
+import * as Sentry from "@sentry/nextjs";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 1.0,
+});

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,0 +1,6 @@
+import * as Sentry from "@sentry/nextjs";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 1.0,
+});


### PR DESCRIPTION
## Summary
- integrate Sentry and Logtail stubs
- scaffold Jest and Cypress testing along with Chromatic script
- document environment variables in template

## Testing
- `npm test` *(fails: jest: not found)*
- `npx cypress run` *(fails: 403 Forbidden to download cypress)*
- `npx chromatic --exit-zero-on-changes` *(fails: 403 Forbidden to download chromatic)*
- `npm run lint` *(fails: Cannot find module '@sentry/nextjs')*

------
https://chatgpt.com/codex/tasks/task_e_68a6457c39d8832085bf0abb2f140277